### PR TITLE
Fix BaseDAO subclass validation bug

### DIFF
--- a/src/dao/base.py
+++ b/src/dao/base.py
@@ -1,4 +1,4 @@
-from typing import Generic, Sequence, Type, TypeVar
+from typing import Generic, Sequence, TypeVar
 
 from loguru import logger
 from pydantic import BaseModel
@@ -12,10 +12,11 @@ T = TypeVar("T", bound=Base)
 
 
 class BaseDAO(Generic[T]):
-    model = Type[T]
+    model: type[T]
 
     def __init_subclass__(cls, **kwargs):
-        if not hasattr(cls, "model"):
+        super().__init_subclass__(**kwargs)
+        if "model" not in cls.__dict__:
             raise NotImplementedError(f"{cls.__name__} must define a 'model' class attribute")
 
     @classmethod


### PR DESCRIPTION
## Summary
- prevent DAO subclasses from skipping model definition by using a type annotation
- strengthen subclass validation in BaseDAO

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c8f265f0832eae3b2e00075286ab